### PR TITLE
Clean up the intermediate objects to avoid warning

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -32,9 +32,9 @@ $(STATLIB):
 	  fi
 
 clean_intermediate:
-	rm -Rf $(STATLIB) ./rust/.cargo
+	rm -f $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
 .PHONY: all clean_intermediate clean

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -11,7 +11,7 @@ PKG_LIBS = -L$(LIBDIR) -lsudachir2
 
 CARGO_BUILD_ARGS = --lib --profile $(PROFILE) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
-all: C_clean
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -31,8 +31,10 @@ $(STATLIB):
 	    cargo +nightly build $(CARGO_BUILD_ARGS) --target $(TARGET) -Zbuild-std=panic_abort,std; \
 	  fi
 
-C_clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+clean_intermediate:
+	rm -Rf $(STATLIB) ./rust/.cargo
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+
+.PHONY: all clean_intermediate clean

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -31,7 +31,7 @@ $(STATLIB):
 	    cargo +nightly build $(CARGO_BUILD_ARGS) --target $(TARGET) -Zbuild-std=panic_abort,std; \
 	  fi
 
-clean_intermediate:
+clean_intermediate: $(SHLIB)
 	rm -f $(STATLIB)
 
 clean:

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -32,9 +32,9 @@ $(STATLIB):
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 clean_intermediate:
-	rm -Rf $(STATLIB) ./rust/.cargo
+	rm -f $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
 .PHONY: all clean_intermediate clean

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -31,7 +31,7 @@ $(STATLIB):
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
-clean_intermediate:
+clean_intermediate: $(SHLIB)
 	rm -f $(STATLIB)
 
 clean:

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -14,7 +14,7 @@ PKG_LIBS = -L$(LIBDIR) -lsudachir2 -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdl
 # to overwrite it via configuration.
 CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 
-all: C_clean
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -31,8 +31,10 @@ $(STATLIB):
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
-C_clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+clean_intermediate:
+	rm -Rf $(STATLIB) ./rust/.cargo
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/.cargo ./rust/vendor ./rust/target
+
+.PHONY: all clean_intermediate clean


### PR DESCRIPTION
From some days ago, `R CMD check` checks the compiled code in the sub-directories and it gives this warning. This is false positive. `‘rust/target/release/lib<package name>.a` is not necessary after generating `SHLIB`. However, with the current `Makevars.*`, it doesn't get cleaned up at the time of the check.

This pull request moves the clean up earlier by making it the subsequent step to `$(SHLIB)`.

```
  File ‘string2path/libs/string2path.so’:
    Found ‘_exit’, possibly from ‘_exit’ (C)
      Object: ‘rust/target/release/libstring2path.a’
    Found ‘abort’, possibly from ‘abort’ (C)
      Object: ‘rust/target/release/libstring2path.a’
    Found ‘exit’, possibly from ‘exit’ (C)
      Object: ‘rust/target/release/libstring2path.a’
  
  Compiled code should not call entry points which might terminate R nor
  write to stdout/stderr instead of to the console, nor use Fortran I/O
  nor system RNGs nor [v]sprintf.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual
```

More details can be found:

- https://github.com/yutannihilation/savvy/issues/355
- https://github.com/yutannihilation/savvy/pull/357